### PR TITLE
Add Pan Out

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.
 - [Claude Usage Tracker](https://chromewebstore.google.com/detail/claude-usage-tracker/knemcdpkggnbhpoaaagmjiigenifejfo) -  Chrome extension for tracking Claude AI usage and performance metrics.
 
+### 🍳 Domain-Specific Skills
+
+- [Pan Out](https://github.com/alexeyv/pan-out#readme) - AI cooking companion plugin for Claude Code. Four skills handle the full arc — research the science, build a protocol, guide the cook with voice and timers, debrief afterward to improve next time.
+
 ---
 
 ## 💻 Applications


### PR DESCRIPTION
## Summary

[Pan Out](https://github.com/alexeyv/pan-out#readme) is an open-source (MIT) skills plugin for Claude Code that turns it into an AI cooking companion. It provides four skills covering the full cooking arc:

- **Research** the food science behind a dish
- **Build a protocol** (structured recipe with phases, temperatures, and sensory cues)
- **Guide the cook** in real time with voice callouts and timers
- **Debrief** afterward to capture lessons and improve next time

It fits the **Extensions & Integrations** section as a domain-specific Claude Code plugin. Pan Out is actively maintained and has documentation at [panout.org](https://panout.org).