### PR TITLE
Add Watchfire to Applications > Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
+- [Watchfire](https://github.com/watchfire-io/watchfire#readme) -  Orchestration platform for AI coding agents. Manages project context, breaks work into tasks, and runs agents with full codebase awareness using git worktrees for isolation. Includes a Go daemon, CLI/TUI, and Electron GUI.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds [Watchfire](https://github.com/watchfire-io/watchfire) to the **Applications > Desktop** section
- Watchfire is an orchestration platform for AI coding agents (starting with Claude Code) that manages project context, breaks work into tasks, and runs agents with full codebase awareness
- Uses git worktrees for isolation, sandboxed execution, and supports multiple agent modes (chat, task, wildfire/autonomous)
- Ships with three components: Go daemon, CLI/TUI, and Electron GUI — the Electron GUI makes it a fit for the Desktop subsection
- [61 stars](https://github.com/watchfire-io/watchfire), Apache 2.0 license
- Website: https://watchfire.io

## Test plan

- [ ] Verify the entry follows the existing format (`- [Name](URL) -  Description.`)
- [ ] Confirm the link resolves correctly
- [ ] Check alphabetical/logical ordering within the Desktop section

🤖 Generated with [Claude Code](https://claude.com/claude-code)