### PR TITLE
Add getburnd — local-first cost-control CLI for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Terminal-first agentic coding tool (CLI), with VS Code/JetBrains IDE integration
 - [Claude Desktop](https://claude.ai/download) -  macOS + Windows app; includes **Cowork** GUI for non-technical workflows and the dedicated **Code** tab.
 - Install CLI: `curl -fsSL https://claude.ai/install.sh | bash` (macOS/Linux) or via Homebrew/Winget.
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Integrates with Claude Code for browser control (multi-tab workflows, Slack, Gmail, GitHub).
+- [getburnd](https://github.com/garvitsurana271/burnd) -  Local-first cost-control CLI (`npx getburnd`). Reads `~/.claude/projects/*.jsonl` offline, identifies 8 cost-leak patterns, prints ranked savings estimates, and generates a shareable report URL. MIT, zero telemetry.
 
 ### 🔌 Model Context Protocol (MCP)
 


### PR DESCRIPTION
## What

Adds [getburnd](https://github.com/garvitsurana271/burnd) under the Claude Code section.

## Description

`getburnd` is a local-first CLI for Claude Code users who want to find where their token budget is leaking. It reads `~/.claude/projects/*.jsonl` session files entirely offline, identifies 8 cost-leak patterns (verbose context, tool loops, large file re-reads, orphaned sessions), and prints ranked savings estimates.

- **Install:** `npx getburnd`  
- **License:** MIT  
- **Zero telemetry:** local files only, nothing uploaded  
- Generates shareable report URL (client-side base64url hash — no backend)  
- OpenClaw agent support: `npx getburnd openclaw`

Homepage: https://getburnd.vercel.app