### PR TITLE
Add Screenpipe MCP under Model Context Protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
+- [Screenpipe MCP](https://github.com/screenpipe/screenpipe/tree/main/crates/screenpipe-connect/screenpipe-mcp) -  Local MCP server that exposes 24/7 screen + microphone recordings (OCR + audio transcription + UI tree) to Claude. Search everything you've seen, said, or heard. 100% local SQLite, MIT licensed.
 
 ---
 


### PR DESCRIPTION
This submission is withdrawn because the contribution guidelines require open-source projects. Screenpipe now uses the [Screenpipe Commercial License](https://github.com/screenpipe/screenpipe/blob/main/LICENSE.md), so the earlier MIT claim was incorrect.

The old MCP source link is also obsolete. Current code lives in [packages/screenpipe-mcp](https://github.com/screenpipe/screenpipe/tree/main/packages/screenpipe-mcp). Capture storage is local by default; connected assistants and configured cloud services can process context off-device.

Disclosure: I maintain Screenpipe. I am closing this PR to respect the list's eligibility rules.
