### PR TITLE
feat: add Suede Creator Skills to Community Curated Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [hesreallyhim/awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code#readme) -  Slash-commands, CLAUDE.md files, CLI tools, and workflows for Claude Code.
 - [travisvn/awesome-claude-skills](https://github.com/travisvn/awesome-claude-skills#readme) -  Resources and tools for customizing AI workflows with Claude Skills.
 - [BehiSecc/awesome-claude-skills](https://github.com/BehiSecc/awesome-claude-skills#readme) -  Categorized skills for document handling, development tools, data analysis, and more.
+- [JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills#readme) -  21-skill pack for music creator workflows: rights, provenance, campaigns, SEO/AEO/AI EO, code grading, design QA, and agent commerce prep.
 - [langgptai/awesome-claude-prompts](https://github.com/langgptai/awesome-claude-prompts#readme) -  Collection of prompt examples designed to improve Claude interactions.
 - [vijaythecoder/awesome-claude-agents](https://github.com/vijaythecoder/awesome-claude-agents#readme) -  Team of specialized AI agents for building features and debugging.
 - [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents#readme) -  100+ specialized AI agents for full-stack development maintained by the community.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [hesreallyhim/awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code#readme) -  Slash-commands, CLAUDE.md files, CLI tools, and workflows for Claude Code.
 - [travisvn/awesome-claude-skills](https://github.com/travisvn/awesome-claude-skills#readme) -  Resources and tools for customizing AI workflows with Claude Skills.
 - [BehiSecc/awesome-claude-skills](https://github.com/BehiSecc/awesome-claude-skills#readme) -  Categorized skills for document handling, development tools, data analysis, and more.
-- [JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills#readme) -  21-skill pack for music creator workflows: rights, provenance, campaigns, SEO/AEO/AI EO, code grading, design QA, and agent commerce prep.
+- [JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills#readme) - Open-source skill pack for music creator workflows: rights, provenance, campaigns, SEO/AEO/AI EO, code grading, design QA, and agent commerce prep.
 - [langgptai/awesome-claude-prompts](https://github.com/langgptai/awesome-claude-prompts#readme) -  Collection of prompt examples designed to improve Claude interactions.
 - [vijaythecoder/awesome-claude-agents](https://github.com/vijaythecoder/awesome-claude-agents#readme) -  Team of specialized AI agents for building features and debugging.
 - [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents#readme) -  100+ specialized AI agents for full-stack development maintained by the community.


### PR DESCRIPTION
Adds [JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) to the Community Curated Lists section — a free MIT-licensed 21-skill pack for Claude Code and Codex covering music creator workflows, rights, provenance, campaigns, SEO/AEO/AI EO, code grading, design QA, and agent commerce prep.