### PR TITLE
Add Desktop Agent Bridge under Desktop applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
+- [Desktop Agent Bridge](https://github.com/WarrenJones/desktop-agent-bridge#readme) -  Local-first macOS bridge that lets Claude Desktop and Codex Desktop open visible peer-review sessions for each other, carry source-conversation context, and return findings to the originating session.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add Desktop Agent Bridge under `Applications > Desktop`.
- Describe its bidirectional native Claude Desktop and Codex Desktop peer-review handoff, source-conversation context, and returned findings.

## Why it fits

Desktop Agent Bridge is an open-source, local-first macOS integration for Claude Desktop users who also work with Codex Desktop. The entry links to the public repository and follows the existing one-line application format.

## Validation

- `git diff --check` passes.
- The added line is not reported by `awesome-lint`.
- `npm test` currently reports the same 49 pre-existing errors on unmodified `upstream/main`, including the unauthenticated GitHub API rate limit and existing table-of-contents/duplicate-link findings.