### PR TITLE
Add Terminal subsection under Applications with claudectl

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,9 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
 
+### ⌨️ Terminal
+
+- [claudectl](https://github.com/babarmuhammad/claudectl) -  Workspace manager for Claude Code sessions: browsable session history, token-budgeted project memory, MCP server visibility, and per-project launch settings. Terminal UI and desktop GUI, Python standard library only.
 ---
 
 ## 📚 Educational Resources


### PR DESCRIPTION
Applications currently has only a Desktop subsection, so there is no place for terminal-based Claude Code tooling. This adds a Terminal subsection with one entry.

claudectl is a workspace layer for Claude Code: it browses and searches past sessions per project, maintains a token-budgeted project memory (a bounded index in CLAUDE.md plus path-scoped rules that load only when relevant), shows which MCP servers a project has configured, and stores per-project launch settings. Terminal UI and desktop GUI over the same engine.

MIT, Python 3.10+, zero runtime dependencies, on PyPI as `claudectl`. Docs: https://babarmuhammad.github.io/claudectl/

Happy to drop the new subsection and place it under Desktop instead if you'd prefer not to add structure.