### PR TITLE
Add LWC local-first project memory MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
+- [LWC (Local Wiki CLI)](https://github.com/JanYork/llm-wiki-cli) - Local-first project memory with source-grounded retrieval, durable Markdown and SQLite storage, and a read-only MCP interface for Claude Code and other coding agents.
 
 ---
 


### PR DESCRIPTION
Adds [LWC (Local Wiki CLI)](https://github.com/JanYork/llm-wiki-cli) to the Model Context Protocol section.

Why it belongs:
- open-source Apache-2.0 project with active releases and documented installation
- provides durable, source-grounded project memory through a bounded read-only MCP tool
- integrates with Claude Code as well as other coding agents

This PR adds one entry only and follows the requested list format.