### PR TITLE
Add agent-qa to Claude Code tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Terminal-first agentic coding tool (CLI), with VS Code/JetBrains IDE integration
 - [Claude Desktop](https://claude.ai/download) -  macOS + Windows app; includes **Cowork** GUI for non-technical workflows and the dedicated **Code** tab.
 - Install CLI: `curl -fsSL https://claude.ai/install.sh | bash` (macOS/Linux) or via Homebrew/Winget.
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Integrates with Claude Code for browser control (multi-tab workflows, Slack, Gmail, GitHub).
+- [agent-qa](https://github.com/vostride/agent-qa) - Open-source self-improving QA agent with Claude Code authentication and agent skills for running natural-language web and mobile tests.
 
 ### 🔌 Model Context Protocol (MCP)
 


### PR DESCRIPTION
## Summary

Adds agent-qa to the Claude Code section.

agent-qa is an open-source self-improving QA agent for software teams. Its direct Claude Code integration includes subscription authentication and installable agent skills, while its QA runtime executes natural-language web and mobile tests. The project is publicly documented, actively maintained, and has 764 GitHub stars.

## Checklist

- [x] Searched prior suggestions and the current list for duplicates
- [x] Added one project at the bottom of the relevant category
- [x] Used the documented one-line project format
- [x] Kept the description factual and ended it with a period
- [x] Verified the project URL