### PR TITLE
Add Aeon under a new Agent Frameworks subsection

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.
 - [Claude Usage Tracker](https://chromewebstore.google.com/detail/claude-usage-tracker/knemcdpkggnbhpoaaagmjiigenifejfo) -  Chrome extension for tracking Claude AI usage and performance metrics.
 
+### 🤖 Agent Frameworks
+
+- [Aeon](https://github.com/aeonfun/aeon) -  Autonomous agent framework built on Claude Code that runs entirely on GitHub Actions. Cron-scheduled Markdown skills self-heal, replicate into a fleet, and ship 70+ Agent Skills across six coding-agent harnesses.
+
 ---
 
 ## 💻 Applications


### PR DESCRIPTION
Adding **[Aeon](https://github.com/aeonfun/aeon)** under a new **Extensions & Integrations -> Agent Frameworks** subsection.

Aeon is an autonomous agent framework built on Claude Code that runs entirely on GitHub Actions, with no long-lived server. Cron-scheduled Markdown skills self-heal (a health skill detects failures and a repair skill fixes them by PR), spawn a fleet of clones, and ship 70+ Agent Skills across six coding-agent harnesses (Claude Code default, plus Grok, Codex, Pi, Vibe, Kimi).

- Repo: https://github.com/aeonfun/aeon
- License: MIT · 666 stars · actively maintained (daily commits)
- Meets the project standards: open source, actively maintained (daily commits), documented, meaningful functionality.
- The contributing guide welcomes new categories; there was no existing home for community frameworks built on Claude Code, so I added a small "Agent Frameworks" subsection. Happy to move it into a different category if you prefer.

Single entry, format follows `- [Name](URL) - Description.` and is added at the position noted above.