### PR TITLE
Add "What a Claude Agent Actually Costs" to Community Guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [40+ Claude Code Tips](https://github.com/ykdojo/claude-code-tips#readme) -  Tips for getting the most out of Claude Code, including a custom status line script, cutting the system prompt in half, using Gemini CLI as Claude Code's minion, and Claude Code running itself in a container. Also includes the dx plugin for GitHub Actions debugging, conversation cloning, and handoffs.
 - [My Experience With Claude Code After 2 Weeks of Adventures](https://sankalp.bearblog.dev/my-claude-code-experience-after-2-weeks-of-usage/) - Part 1: Real-world lessons on using a `TODO.md` file to keep Claude on track, managing costs, and why it often outperforms Cursor for complex refactors.
 - [A Guide to Claude Code 2.0 and getting better at using coding agents](https://sankalp.bearblog.dev/my-experience-with-claude-code-20-and-how-to-get-better-at-using-coding-agents/#setup) - Part 2: A deep dive into the 2.0 update, focusing on the "Agent Manager" mindset, context engineering, and using sub-agents for larger codebases.
+- [What a Claude Agent Actually Costs](https://aiarch.dev/claude-agent-cost) - Token rates per model, what Bedrock and an AI Gateway add on top, subscription versus API for Claude Code, and a worked method for estimating a multi-turn agent's bill. Includes the per-role router and rate table running the site it is published on.
 
 ---
 


### PR DESCRIPTION
Adds an as-built cost guide for Claude agents to Educational Resources → Community Guides.

Covers the per-model token rates, what each platform adds on top of tokens (Bedrock, AI Gateway, Claude Code subscription vs API), and a step-by-step method for estimating a multi-turn agent's bill rather than a single request's.

Why it belongs here: the list currently links Anthropic's models-and-pricing reference, which gives rates but not a method. This is the arithmetic between the rate card and a monthly bill. It closes with the as-built router and rate table from the site's own production Worker, so the numbers are ones we run against rather than illustrative.