### PR TITLE
Add APITube News MCP to the Model Context Protocol section

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
+- [APITube News MCP](https://github.com/apitube/news-api-mcp) -  Hosted MCP server for news search across 500,000+ sources in 177 countries and 59 languages, returning sentiment and named entities with every article. Streamable HTTP, API key required.
 
 ---
 


### PR DESCRIPTION
Adds the APITube News MCP server to the **Model Context Protocol (MCP)** section, at the bottom of the list.

```
- [APITube News MCP](https://github.com/apitube/news-api-mcp) -  Hosted MCP server for news search across 500,000+ sources in 177 countries and 59 languages, returning sentiment and named entities with every article. Streamable HTTP, API key required.
```

### Why it fits here

The MCP section currently points at the spec, the two Anthropic courses and punkpeye's list — everything a reader needs to *learn* MCP, but no server they can connect Claude to. This is a working server that takes one line of config and gives Claude live news as structured data instead of scraped HTML.

| Property | Value |
|----------|-------|
| Endpoint | `https://mcp.apitube.io/` — hosted, nothing to install |
| Transport | Streamable HTTP (`POST /`), JSON-RPC 2.0 |
| Protocol | `2025-11-25`, negotiated down (`2024-11-05` works) |
| Auth | `Authorization: Bearer <API_KEY>` or `X-API-Key: <API_KEY>` |
| Registry | `io.apitube/news` in the official MCP Registry |
| Repository | [apitube/news-api-mcp](https://github.com/apitube/news-api-mcp), MIT |
| Docs | https://docs.apitube.io/platform/news-api/ai/mcp-server |

### Tools

- **`search_news`** — most of the News API filter set in one call: keywords, language, country, source domain and quality rank, sentiment range, named entities, media, date ranges, sorting, faceting and highlighting.
- **`suggest`** — resolves a name like "Tesla" into the entity, category, topic and industry IDs that the precise filters take.

Four prompts ship with it as slash commands in MCP clients: `monitor_company`, `topic_sentiment`, `breaking_news`, `compare_coverage`.

### Verify without a key

The server answers `initialize` and `tools/list` unauthenticated, so the tool list is checkable in one command:

```bash
curl -s https://mcp.apitube.io/ \
  -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
```

### Disclosure and caveats

- I work on APITube, so this is a self-submission — flagging it rather than hiding it.
- The server is hosted, and the repository holds its docs, client configs and `server.json` rather than a self-hostable codebase. If the list only wants projects you can run yourself, say so and I'll close this.
- MCP access is on the paid plans; the free tier (100 requests/day) covers the REST API only. Pricing: [apitube.io/pricing](https://apitube.io/pricing).
- Related open-source repositories under the same org, kept current: [news-api-node](https://github.com/apitube/news-api-node), [news-api-python](https://github.com/apitube/news-api-python), [news-api-php](https://github.com/apitube/news-api-php), [news-api-dart](https://github.com/apitube/news-api-dart), [news-api-skills](https://github.com/apitube/news-api-skills) (Agent Skill for Claude Code).

Format follows `contributing.md`: single suggestion, `- [Name](link) - Description.`, appended to the bottom of the category.
