### PR TITLE
Add interactive-code-map agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 ## 🧩 Extensions & Integrations
 
+### 🤖 Agent Skills
+
+- [interactive-code-map](https://github.com/YuLaiZ/interactive-code-map#readme) -  Cross-client skill that turns a codebase or business process into a single interactive HTML map with evidence states and verified line-level citations.
+
 ### 🎨 IDE Extensions
 
 - [Claude Code for VS Code](https://marketplace.visualstudio.com/items?itemName=Anthropic.claude-code) -  Official Anthropic extension. Inline diffs, `@`-mentions, plan review, conversation history, and full Claude Code integration.


### PR DESCRIPTION
## Summary

Adds [interactive-code-map](https://github.com/YuLaiZ/interactive-code-map) under a new **Agent Skills** subsection of Extensions & Integrations.

## Why it belongs

interactive-code-map is an open-source, MIT-licensed cross-client agent skill that turns a codebase — or a described business process — into a single interactive HTML map. Unlike generic diagram skills, every assertion carries an explicit verified/inferred/unconfirmed state, and verified claims must cite file-and-line evidence the agent actually inspected, so the map cannot silently hallucinate.

- Public repo, actively maintained, MIT license
- Zero-dependency Node builder; self-contained skill package with bilingual SKILL.md
- Online demo (no install needed): https://yulaiz.github.io/interactive-code-map/en/
- Test coverage: MapSpec, build, schema-diff, and Playwright browser suites

Format follows the existing list style (`- [Name](link) - Description.`, capitalized, period-terminated).