### PR TITLE
Add claude-carbon (carbon footprint tracking for Claude Code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Terminal-first agentic coding tool (CLI), with VS Code/JetBrains IDE integration
 - [Claude Desktop](https://claude.ai/download) -  macOS + Windows app; includes **Cowork** GUI for non-technical workflows and the dedicated **Code** tab.
 - Install CLI: `curl -fsSL https://claude.ai/install.sh | bash` (macOS/Linux) or via Homebrew/Winget.
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Integrates with Claude Code for browser control (multi-tab workflows, Slack, Gmail, GitHub).
+- [claude-carbon](https://github.com/gwittebolle/claude-carbon) -  Open-source carbon footprint tracker for Claude Code sessions: live CO2 estimate in the status line, reports, and shareable PNG cards.
 
 ### 🔌 Model Context Protocol (MCP)
 


### PR DESCRIPTION
Adds [claude-carbon](https://github.com/gwittebolle/claude-carbon), an MIT-licensed tool that tracks the CO2 footprint of Claude Code sessions: live estimate in the status line, per-model session reports, and shareable PNG report cards (EN/FR). 160+ stars, actively maintained since April 2026, methodology publicly documented. I'm the author.

Placed it at the end of the Claude Code subsection - happy to move it to a different section if you prefer.
