### PR TITLE
Add AdMapix MCP to the MCP resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
+- [AdMapix MCP](https://www.admapix.com) ([source](https://github.com/fly0pants/admapix)) -  Search global advertising creatives by keyword, platform, country, language, and date through an MCP server.
 
 ---
 


### PR DESCRIPTION
## Summary
- add AdMapix MCP to the Model Context Protocol resources section
- link the public AdMapix homepage and source repository
- describe the server using its documented creative-search capabilities

The entry follows the existing list format and is relevant to Claude users looking for advertising intelligence tools.