### PR TITLE
Add Chat Threads to Browser Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.
 - [Claude Usage Tracker](https://chromewebstore.google.com/detail/claude-usage-tracker/knemcdpkggnbhpoaaagmjiigenifejfo) -  Chrome extension for tracking Claude AI usage and performance metrics.
+- [Chat Threads](https://github.com/onyourmark/chat-threads) -  Open-source side panel that reshapes a long Claude or ChatGPT conversation: read back only your own prompts, remove or edit individual turns, and split one conversation into separate topic conversations. Works on a copy, so the original is never modified.
 
 ---
 


### PR DESCRIPTION
Adding [Chat Threads](https://github.com/onyourmark/chat-threads) to *Extensions & Integrations → Browser Extensions*.

An open-source (MIT) Chrome and Edge side panel for reshaping a long Claude or ChatGPT conversation. Read back only your own prompts with replies one click away, exclude or edit individual turns, and split one conversation into separate topic conversations to paste into a new chat and continue from clean context.

It works on a copy. Chat Threads issues read requests only, so the conversation on claude.ai is never modified — the retrieved conversation is frozen in memory and every edit applies to a separate working copy.

- Open source, MIT, public repository, TypeScript, MV3, 348 tests.
- No backend, no account, no analytics, no telemetry, no remote code.
- No host permissions at install time. It uses `activeTab`, so it cannot read a page until you click its toolbar icon, and that access ends when you navigate away.
- Optional topic suggestions use the user's own Anthropic or OpenAI API key. Everything else works with no key and makes no network requests.

Being upfront about the contributing guidelines: the repository is new, so it has no meaningful star count yet. Happy for you to hold or close this if you would rather wait for the project to build some traction — no hard feelings either way.

Not affiliated with or endorsed by Anthropic.