### PR TITLE
Add Find Image Prompt Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ Terminal-first agentic coding tool (CLI), with VS Code/JetBrains IDE integration
 - Install CLI: `curl -fsSL https://claude.ai/install.sh | bash` (macOS/Linux) or via Homebrew/Winget.
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Integrates with Claude Code for browser control (multi-tab workflows, Slack, Gmail, GitHub).
 
+### 🧩 Agent Skills
+
+- [Find Image Prompt Skill](https://github.com/jasonliu119/find-image-prompt-skill) - Portable SKILL.md integration for turning ideas and public reference images into model-ready image prompts.
+
 ### 🔌 Model Context Protocol (MCP)
 
 Open standard (Linux Foundation) for connecting Claude to tools, repos, databases, tickets, and more. Supports one-click desktop extensions (`.mcpb` files).


### PR DESCRIPTION
**Find Image Prompt Skill**
An open, portable skill for AI agents that turn creative ideas or public reference images into production-ready image prompts and image descriptions.

Find Image Prompt is built around a standard SKILL.md entrypoint and an HTTP API, so it is not tied to one agent, model, or framework. Use it with any agent host that can load a skill, make HTTP requests, or call tools—for example, coding agents, custom assistants, workflow automations, and creative applications.

**What the skill does**
Turn a text idea into a polished image-generation prompt.
Analyze a public reference image and turn its visual direction into a reusable prompt.
Describe visible subjects, objects, style, or text in a public image.
Format prompt output for ChatGPT Images, Gemini, Midjourney, Flux, and Stable Diffusion.
Give agents clear operation selection, authentication, safety, and error-handling guidance.

Website: [Find Image Prompt — AI Image Prompt Generator](https://findimageprompt.com/)