### PR TITLE
Add Find Image Prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.
 - [Claude Usage Tracker](https://chromewebstore.google.com/detail/claude-usage-tracker/knemcdpkggnbhpoaaagmjiigenifejfo) -  Chrome extension for tracking Claude AI usage and performance metrics.
+- [Find Image Prompt Skill](https://github.com/jasonliu119/find-image-prompt-skill) - An open, portable SKILL.md that lets any skill-capable agent turn ideas and public reference images into model-ready image prompts, via a documented API.
 
 ---
 


### PR DESCRIPTION
Adds [Find Image Prompt](https://findimageprompt.com/) to `README.md`.

> An open, portable SKILL.md that lets any skill-capable agent turn ideas and public reference images into model-ready image prompts, via a documented API.

Open source skill: https://github.com/jasonliu119/find-image-prompt-skill
