### PR TITLE
Add WebMCP Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Terminal-first agentic coding tool (CLI), with VS Code/JetBrains IDE integration
 - [Claude Desktop](https://claude.ai/download) -  macOS + Windows app; includes **Cowork** GUI for non-technical workflows and the dedicated **Code** tab.
 - Install CLI: `curl -fsSL https://claude.ai/install.sh | bash` (macOS/Linux) or via Homebrew/Winget.
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Integrates with Claude Code for browser control (multi-tab workflows, Slack, Gmail, GitHub).
+- [WebMCP Kit](https://github.com/nekuda-ai/webmcp-kit) -  Coding-agent plugin that maps a web app's user journeys in a visual Explorer, proposes WebMCP tools for approval, implements them through the app's own logic, and verifies each tool in a real browser.
 
 ### 🔌 Model Context Protocol (MCP)
 


### PR DESCRIPTION
## Summary

Add WebMCP Kit to the Claude Code section and highlight its visual Explorer and real-browser verification workflow.

## Fit

- **Real use case:** turns an existing website or web app into an agent-ready product by implementing WebMCP tools through the app's own logic instead of scraping the page.
- **Not duplicative:** a repository-wide search found no existing WebMCP implementation plugin listing; the existing awesome-webmcp link is a broader resource list, not an implementation tool.
- **Tested:** the plugin ships automated tests, its focused public test set passes 43 checks, and its workflow verifies each generated tool in a real browser before reporting it as verified.

## Validation

- `git diff --check`
- WebMCP Kit repository link responds successfully
