### PR TITLE
Add claude-forge to Claude Code section

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Terminal-first agentic coding tool (CLI), with VS Code/JetBrains IDE integration
 - [Claude Desktop](https://claude.ai/download) -  macOS + Windows app; includes **Cowork** GUI for non-technical workflows and the dedicated **Code** tab.
 - Install CLI: `curl -fsSL https://claude.ai/install.sh | bash` (macOS/Linux) or via Homebrew/Winget.
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Integrates with Claude Code for browser control (multi-tab workflows, Slack, Gmail, GitHub).
+- [claude-forge](https://github.com/sangrokjung/claude-forge) - Community setup framework for Claude Code that bundles agents, slash commands, skills, and safety hooks into a single install (MIT).
 
 ### 🔌 Model Context Protocol (MCP)
 


### PR DESCRIPTION
Adding claude-forge: https://github.com/sangrokjung/claude-forge

It's an MIT-licensed setup framework for Claude Code: agents, slash commands,
skills, and safety hooks (things like guarding destructive shell commands)
installed in one step, similar in spirit to what oh-my-zsh does for zsh.
It also ships an adversarial review loop where a second agent reviews changes
without seeing the first agent's reasoning.

Why it fits: open source, actively maintained (commits within the last week),
documented install/usage, and it targets Claude Code specifically rather than
being a generic LLM tool.

Disclosure: I'm the author.