### PR TITLE
Add a Plugins & Skills subsection under Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,14 @@ Terminal-first agentic coding tool (CLI), with VS Code/JetBrains IDE integration
 - Install CLI: `curl -fsSL https://claude.ai/install.sh | bash` (macOS/Linux) or via Homebrew/Winget.
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Integrates with Claude Code for browser control (multi-tab workflows, Slack, Gmail, GitHub).
 
+### 🔌 Plugins & Skills
+
+Third-party plugin marketplaces and skills installed with `/plugin marketplace add`.
+
+- [claude-code-templates](https://github.com/davila7/claude-code-templates#readme) -  Registry of agents, commands, skills, hooks and MCPs, with a browsable web catalogue. ⭐ 30k+
+- [superpowers-marketplace](https://github.com/obra/superpowers-marketplace#readme) -  Marketplace of composable skills for planning, research and code review. ⭐ 1.2k+
+- [html2wp](https://github.com/iOSDevSK/html2wp-cc-plugin#readme) -  Converts a static HTML site into a standalone WordPress block theme and verifies the result against the original. Source-available, not open source.
+
 ### 🔌 Model Context Protocol (MCP)
 
 Open standard (Linux Foundation) for connecting Claude to tools, repos, databases, tickets, and more. Supports one-click desktop extensions (`.mcpb` files).


### PR DESCRIPTION
### What this adds

A `### 🔌 Plugins & Skills` subsection under **Claude Code & MCP**.

The list currently covers official Anthropic resources, IDE/browser extensions and desktop apps, but has no place for **third-party plugin marketplaces** — the `/plugin marketplace add` ecosystem, which is where a large part of Claude Code usage now happens. That gap seemed worth closing rather than adding a single entry somewhere it doesn't belong.

Three entries, added at the bottom of the new subsection per the guidelines:

- **[claude-code-templates](https://github.com/davila7/claude-code-templates)** — ⭐ 30k+, registry of agents/commands/skills/hooks/MCPs with a web catalogue.
- **[superpowers-marketplace](https://github.com/obra/superpowers-marketplace)** — ⭐ 1.2k+, composable skills for planning, research and review.
- **[html2wp](https://github.com/iOSDevSK/html2wp-cc-plugin)** — converts a static HTML site into a standalone WordPress block theme, and verifies the output against the original at three viewport widths inside a real WordPress before handover.

### Disclosure, because your standards ask for open source

**html2wp is mine, and it is source-available, not open source.** The repository is public and the plugin installs and runs from it, but the licence forbids republishing it or building a competing converter from it. The theme it produces carries no such restriction.

Your Project Standards say projects must be open source, so if that is applied strictly, **please drop that one line and merge the other two** — the subsection is worth having either way, and I would rather say this up front than have you find it later.

The other two entries are genuinely open source and both are actively maintained.

### Checks

- One PR, one suggestion (the subsection).
- Format `- [Name](URL) -  Description.`, descriptions capitalised and full-stopped, star counts included for the 1k+ projects.
- Contents list untouched: it indexes `##` sections only, and this is a `###` under an existing one.
- No trailing whitespace.
