### PR TITLE
Add Skills Directory (security-scanned skills directory) to Community Curated Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [hesreallyhim/awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code#readme) -  Slash-commands, CLAUDE.md files, CLI tools, and workflows for Claude Code.
 - [travisvn/awesome-claude-skills](https://github.com/travisvn/awesome-claude-skills#readme) -  Resources and tools for customizing AI workflows with Claude Skills.
 - [BehiSecc/awesome-claude-skills](https://github.com/BehiSecc/awesome-claude-skills#readme) -  Categorized skills for document handling, development tools, data analysis, and more.
+- [Skills Directory](https://www.skillsdirectory.com) -  Searchable directory of 100,000+ Claude/agent skills; every skill is automatically security-scanned and graded A–F before listing.
 - [langgptai/awesome-claude-prompts](https://github.com/langgptai/awesome-claude-prompts#readme) -  Collection of prompt examples designed to improve Claude interactions.
 - [vijaythecoder/awesome-claude-agents](https://github.com/vijaythecoder/awesome-claude-agents#readme) -  Team of specialized AI agents for building features and debugging.
 - [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents#readme) -  100+ specialized AI agents for full-stack development maintained by the community.


### PR DESCRIPTION
Adds [Skills Directory](https://www.skillsdirectory.com) to the Community Curated Lists section, next to the two awesome-claude-skills lists.

**Disclosure: I run this site.**

Why I think it fits the list:
- 100,000+ Claude/agent skills indexed and searchable (complements the curated GitHub lists already featured)
- Its distinguishing feature: every skill is automatically security-scanned before listing and shows a public A–F grade + per-skill report (credential reads, network exfiltration, unpinned remote code, prompt-injection patterns), so users can vet a skill before installing it into their agent
- Free, no login, and has a public API for querying skills by security grade

Happy to adjust the wording or placement if you'd prefer it elsewhere.