### PR TITLE
Add clautray to Applications › Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
+- [clautray](https://github.com/EmirhanOlgn/clautray) - Cross-platform tray and menu-bar monitor for Claude usage limits (5-hour, weekly, per-model) for Windows, macOS and Linux.
 
 ---
 


### PR DESCRIPTION
Adds [clautray](https://github.com/EmirhanOlgn/clautray) - a cross-platform tray and menu-bar monitor for Claude usage limits (5-hour, weekly, per-model) for Windows, macOS and Linux. Open source (MIT), actively maintained, prebuilt releases for all three platforms. Added to the bottom of the Desktop category in the `- [Name](URL) - Description.` format per contributing.md.