### PR TITLE
Add swissco Swiss company data agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ AI assistant by Anthropic for complex reasoning, code generation, and analysis t
 
 - [🏢 Official Anthropic Resources](#-official-anthropic-resources)
 - [🛠️ Claude Code & Model Context Protocol (MCP)](#️-claude-code--model-context-protocol-mcp)
+- [📦 Agent Skills](#-agent-skills)
 - [⭐ Community Curated Lists](#-community-curated-lists)
 - [🧩 Extensions & Integrations](#-extensions--integrations)
 - [💻 Applications](#-applications)
@@ -135,6 +136,14 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
+
+---
+
+## 📦 Agent Skills
+
+**Reusable [Agent Skills](https://agentskills.io/specification) that teach Claude Code (and other agents) domain-specific workflows**
+
+- [swissco](https://github.com/prospex-ch/swissco-cli) -  Swiss company data from the shell: ten commands over six open-data sources (Zefix, SHAB, simap, FINMA, GLEIF, ARAMIS). Look up a company by UID, search 790,000 companies by name or statutory purpose, list gazette publications, trace registry events, watch companies for change, browse public tenders, check bank licences, resolve a UID to an LEI and group parent, or find federally funded research. No API key, no signup. Install the skill with `npx skills add prospex-ch/swissco-cli`. [Docs](https://swissco.readthedocs.io)
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds [swissco](https://github.com/prospex-ch/swissco-cli) to a new **Agent Skills** section in the README.
- swissco is a zero-config CLI over six Swiss open-data sources (Zefix, SHAB, simap, FINMA, GLEIF, ARAMIS) that ships a cross-agent [Agent Skill](https://agentskills.io/specification) for Claude Code, Cursor, Codex and others.
- Open source (MIT), actively maintained, with full [documentation](https://swissco.readthedocs.io) and [PyPI package](https://pypi.org/project/swissco/).

## Why include it

Agent Skills are a growing category in the Claude ecosystem — tools that teach Claude Code domain-specific workflows. swissco is a practical example: it lets an agent query Swiss commercial-register, gazette, procurement, banking, LEI and research data with ten shell commands, all backed by public government APIs.

The new "Agent Skills" section provides a natural home for this and future skill entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)