### PR TITLE
Add claude-agent-sdk-ruby to Agent SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Model IDs from the 4.6 generation onward are dateless but still pinned snapshots
 
 - [claude-agent-sdk-python](https://github.com/anthropics/claude-agent-sdk-python) -  Python Agent SDK. [Docs](https://platform.claude.com/docs/en/agent-sdk/overview)
 - [claude-agent-sdk-typescript](https://github.com/anthropics/claude-agent-sdk-typescript) -  TypeScript Agent SDK.
+- [claude-agent-sdk-ruby](https://github.com/ya-luotao/claude-agent-sdk-ruby) -  Community-maintained Ruby Agent SDK (unofficial) with Rails integration. [Gem](https://rubygems.org/gems/claude-agent-sdk)
 
 **Starters**
 


### PR DESCRIPTION
Adds the community-maintained Ruby port of the Claude Agent SDK to the **Agent SDKs** subsection, next to the official Python and TypeScript SDKs.

- Repo: https://github.com/ya-luotao/claude-agent-sdk-ruby
- Gem: https://rubygems.org/gems/claude-agent-sdk (MIT)
- Same stream-JSON protocol as the official SDKs; tracks Python SDK releases (currently synced to 0.2.147)
- Covers `query()`, bidirectional `Client`, in-process MCP tools, all 27 hook events, permission callbacks, sessions, sandbox, plus Rails integration and a built-in OpenTelemetry observer

Clearly marked as unofficial in the entry.