### PR TITLE
Add ContextStream to the MCP section

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
+- [ContextStream](https://github.com/contextstream/mcp-server) -  Shared project context for Cursor, Claude Code, Codex, and Grok. Site: https://contextstream.io. Remote MCP: https://mcp.contextstream.io/mcp. Intelligence isn’t the bottleneck. Context is.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [ContextStream](https://contextstream.io) to Claude Code & Model Context Protocol (MCP).

ContextStream is shared project context for Cursor, Claude Code, Codex, and Grok. Intelligence isn’t the bottleneck. Context is.

- Site: https://contextstream.io
- Remote MCP: https://mcp.contextstream.io/mcp
- Open source MCP server (MIT): https://github.com/contextstream/mcp-server
- Benchmarks: https://contextstream.io/benchmarks

The row links the public MCP server so it matches the open-source project standard, and it sits at the bottom of the MCP category.

Disclosure: I work on ContextStream.