### PR TITLE
Add claude-transplant to Desktop applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
+- [claude-transplant](https://github.com/vitaliyhayda/claude-transplant#readme) -  Unofficial macOS menubar and CLI that moves Claude Code session history between accounts in Claude Desktop, so the Code tab is not empty after switching.
 
 ---
 


### PR DESCRIPTION
Adds claude-transplant under Applications, Desktop, in the existing entry format.

Claude Desktop lists Claude Code sessions per account and organization, so switching accounts leaves the Code tab empty. claude-transplant moves the session records to the account you are using, keeps session ids, verifies nothing changed, and has undo. macOS, menubar or CLI, MIT, no dependencies. I am the author.

https://github.com/vitaliyhayda/claude-transplant

🤖 Generated with [Claude Code](https://claude.com/claude-code)